### PR TITLE
feat: add vanilla nixpkgs rust toolchain support

### DIFF
--- a/examples/rust/advanced/default.nix
+++ b/examples/rust/advanced/default.nix
@@ -9,7 +9,7 @@
     rustc = prev.rustc.overrideAttrs (old: {
       version = "1.70.0";
     });
-    
+
     # Add custom rust toolchain
     my-rust-toolchain = prev.rust-bin.stable.latest.default.override {
       extensions = ["rust-src" "rust-analysis" "rustfmt" "clippy"];
@@ -32,23 +32,23 @@ in {
   # Usage with custom overlay
   kernel.rust.custom-overlay = {
     enable = true;
-    overlays = [ myRustOverlay ];
+    overlays = [myRustOverlay];
   };
 
   # Usage with multiple overlays
   kernel.rust.multiple-overlays = {
     enable = true;
-    overlays = [ myRustOverlay extraToolsOverlay ];
+    overlays = [myRustOverlay extraToolsOverlay];
   };
 
   # Usage with custom nixpkgs and extra overlays
   kernel.rust.custom-nixpkgs = {
     enable = true;
-    overlays = [ myRustOverlay ];
+    overlays = [myRustOverlay];
     nixpkgs = {
       # Use a different nixpkgs version (e.g., stable)
       path = self.inputs.nixpkgs-stable;
-      extraOverlays = [ extraToolsOverlay ];
+      extraOverlays = [extraToolsOverlay];
     };
   };
 
@@ -77,4 +77,4 @@ in {
       ];
     };
   };
-} 
+}

--- a/lib/rust-utils.nix
+++ b/lib/rust-utils.nix
@@ -1,0 +1,9 @@
+{lib}: {
+  # Helper function to check if rust-overlay is available in inputs
+  hasRustOverlay = self:
+    (self ? inputs) && (self.inputs ? rust-overlay);
+
+  # Helper function to get rust-overlay default overlay if available
+  getRustOverlay = self:
+    lib.optionals (hasRustOverlay self) [self.inputs.rust-overlay.overlays.default];
+}

--- a/modules/kernels/haskell/default.nix
+++ b/modules/kernels/haskell/default.nix
@@ -127,17 +127,16 @@
                             uuid-types = self.uuid-types_1_0_6;
                             uuid = self.uuid_1_3_16;
                             # https://github.com/ndmitchell/hlint/issues/1593
-                            hlint =
-                              self
+                            hlint = self
                               .hlint_3_8
                               .overrideAttrs (old: {
-                                src = sel.fetchFromGitHub {
-                                  owner = "ndmitchell";
-                                  repo = "hlint";
-                                  rev = "7aafde56f6bc526aedb95fb282d8fd2b4ea290cc";
-                                  sha256 = "sha256-B5aO6pec+Cpxelv7+Mlt1FWjLGwsQCXI0thjCMpXqeE=";
-                                };
-                              });
+                              src = sel.fetchFromGitHub {
+                                owner = "ndmitchell";
+                                repo = "hlint";
+                                rev = "7aafde56f6bc526aedb95fb282d8fd2b4ea290cc";
+                                sha256 = "sha256-B5aO6pec+Cpxelv7+Mlt1FWjLGwsQCXI0thjCMpXqeE=";
+                              };
+                            });
                           };
                         };
                       };

--- a/modules/kernels/rust/default.nix
+++ b/modules/kernels/rust/default.nix
@@ -7,6 +7,7 @@
   ...
 }: let
   inherit (lib) types;
+  rustUtils = import ../../../lib/rust-utils.nix {inherit lib;};
 
   kernelName = "rust";
 
@@ -57,14 +58,22 @@
       evcxr ? pkgs.evcxr,
     }: let
       /*
-      rust-overlay recommends using `default` over `rust`.
-      Pre-aggregated package `rust` is not encouraged for stable channel since it
-      contains almost all and uncertain components.
-      https://github.com/oxalica/rust-overlay/blob/1558464ab660ddcb45a4a4a691f0004fdb06a5ee/rust-overlay.nix#L331
+      Support both rust-overlay and vanilla nixpkgs rust toolchains.
+      rust-overlay provides rust-bin.stable.latest.default with extensions,
+      while vanilla nixpkgs provides separate rustc, cargo, clippy, rustfmt packages.
       */
-      rust = pkgs.rust-bin.stable.latest.default.override {
-        extensions = ["rust-src"];
-      };
+      hasRustBin = pkgs ? rust-bin;
+      rust =
+        if hasRustBin
+        then
+          pkgs.rust-bin.stable.latest.default.override {
+            extensions = ["rust-src"];
+          }
+        else
+          pkgs.symlinkJoin {
+            name = "vanilla-rust-toolchain";
+            paths = with pkgs; [rustc cargo clippy rustfmt];
+          };
 
       allRuntimePackages = requiredRuntimePackages ++ runtimePackages ++ [rust];
 
@@ -79,7 +88,11 @@
             ln -s ${env}/bin/$filename $out/bin/$filename
             wrapProgram $out/bin/$filename \
               --set PATH "${pkgs.lib.makeSearchPath "bin" allRuntimePackages}" \
-              --set RUST_SRC_PATH "${rust}/lib/rustlib/src/rust/library"
+              --set RUST_SRC_PATH "${
+            if hasRustBin
+            then "${rust}/lib/rustlib/src/rust/library"
+            else "${pkgs.rustc}/lib/rustlib/src/rust/library"
+          }"
           done
         '';
     in
@@ -111,12 +124,13 @@
         # Allow users to pass one or more overlay functions directly
         overlays = lib.mkOption {
           type = types.listOf (types.functionTo (types.functionTo types.attrs));
-          default = [self.inputs.rust-overlay.overlays.default];
-          defaultText = lib.literalExpression "[ self.inputs.rust-overlay.overlays.default ]";
+          default = rustUtils.getRustOverlay self;
+          defaultText = lib.literalExpression "if rust-overlay available then [ self.inputs.rust-overlay.overlays.default ] else []";
           example = lib.literalExpression "[ myCustomOverlay ]";
           description = ''
             A list of nixpkgs overlay functions to apply when building the Rust kernel.
             Each overlay should have the form: `final: prev: { … }`.
+            Automatically includes rust-overlay if available, otherwise uses vanilla nixpkgs.
           '';
         };
 

--- a/modules/types/overlays.nix
+++ b/modules/types/overlays.nix
@@ -4,15 +4,14 @@
   self,
   kernelName,
 }: let
+  rustUtils = import ../../lib/rust-utils.nix {inherit lib;};
   overlays =
     if (lib.elem kernelName ["python" "bash" "c" "elm" "zsh" "postgres"])
     then [
       self.inputs.poetry2nix.overlays.default
     ]
     else if kernelName == "rust"
-    then [
-      self.inputs.rust-overlay.overlays.default
-    ]
+    then rustUtils.getRustOverlay self
     else [];
 in
   overlays


### PR DESCRIPTION
- Support both rust-overlay and vanilla nixpkgs toolchains in rust kernel
- Automatically detect if rust-bin is available, otherwise use rustc/cargo
- Handle RUST_SRC_PATH for both toolchain types
- Remove hard dependency on rust-overlay overlay injection
- Maintain backward compatibility with existing rust-overlay users