### PR TITLE
fix: respect jupyenv.pkgs option in flake-module

### DIFF
--- a/flake-module.nix
+++ b/flake-module.nix
@@ -24,7 +24,7 @@ in {
       inherit (jupyenv.lib.${system}) mkJupyterlabNew;
 
       jupyterlab = mkJupyterlabNew ({...}: {
-        nixpkgs = pkgs;
+        nixpkgs = cfg.pkgs;
         imports = [cfg.kernels];
       });
     in {

--- a/lib/jupyter.nix
+++ b/lib/jupyter.nix
@@ -106,6 +106,7 @@
     runtimePackages ? [], # runtime package available to all binaries
     flakes ? [], # flakes where to detect custom kernels/extensions
   }: let
+    pkgs = jupyterlabEnvArgs.pkgs or pkgs;
     allRuntimePackages =
       runtimePackages
       # nodejs and npm are needed to be able to install extensions

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -93,6 +93,7 @@ in {
         pkgs = nixpkgs-poetry;
         inherit
           (config.jupyterlab.jupyterlabEnvArgs)
+
           env
           ;
       };

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -8,9 +8,7 @@
   ...
 }: let
   types = lib.types;
-  nixpkgs-poetry = config.nixpkgs.appendOverlays [
-    self.inputs.poetry2nix.overlays.default
-  ];
+  nixpkgs-poetry = config.nixpkgs.extend self.inputs.poetry2nix.overlays.default;
 in {
   options = {
     jupyterlab = {


### PR DESCRIPTION
Summary
This PR fixes a critical issue where the jupyenv.pkgs option was ignored, preventing custom overlays (like our Node.js fix for Darwin) from being applied to the JupyterLab environment.

Changes
- flake-module.nix: Changed nixpkgs = pkgs to nixpkgs = cfg.pkgs in the mkJupyterlabNew call. This ensures that the configured pkgs instance (defined via the jupyenv.pkgs option) is actually used, rather than defaulting to the module argument.

Impact
This change allows downstream consumers to inject configured nixpkgs instances with overlays. Specifically, it enables us to disable Node.js tests on Darwin to fix local dev environment builds, which were previously failing due to socket path length limitations

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small Nix expression changes that only affect which `pkgs` instance is threaded into the build; main risk is unexpected dependency/version differences for users relying on the previous (incorrect) package set.
> 
> **Overview**
> **Fixes `pkgs`/`nixpkgs` propagation for Jupyenv’s JupyterLab build.** The flake module now passes `cfg.pkgs` (from the `jupyenv.pkgs` option) into `mkJupyterlabNew` instead of always using the perSystem `pkgs`, allowing downstream overlays/custom nixpkgs instances to take effect.
> 
> Additionally, `mkJupyterlab` now explicitly prefers `jupyterlabEnvArgs.pkgs` when computing runtime packages, and the poetry overlay wiring in `modules/default.nix` switches to `config.nixpkgs.extend ...` to build the overlayed package set used for the JupyterLab environment.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4805c4bbb644bcbaec0a5e14459e8adeba1d6ad5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->