### PR TITLE
fix: use extend to preserve overlays in nixpkgs-poetry

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -8,9 +8,7 @@
   ...
 }: let
   types = lib.types;
-  nixpkgs-poetry = config.nixpkgs.appendOverlays [
-    self.inputs.poetry2nix.overlays.default
-  ];
+  nixpkgs-poetry = config.nixpkgs.extend self.inputs.poetry2nix.overlays.default;
 in {
   options = {
     jupyterlab = {


### PR DESCRIPTION
This PR fixes an issue where overlays (such as the nodejs overlay needed for Darwin) were being lost when jupyenv applied its own poetry2nix overlay.

By using `config.nixpkgs.extend` instead of `config.nixpkgs.appendOverlays`, we preserve the existing overlay chain while adding the new one. `appendOverlays` effectively re-imports nixpkgs, which discards any overlays applied to the input pkgs instance.

Fixes #5.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small Nix expression change limited to how overlays are composed; risk is mainly potential differences in package resolution for the Poetry/Jupyter env.
> 
> **Overview**
> Updates `modules/default.nix` to apply the `poetry2nix` overlay via `config.nixpkgs.extend` instead of `appendOverlays`, avoiding a nixpkgs re-import.
> 
> This preserves any overlays already applied to the incoming `config.nixpkgs` (e.g., platform-specific overlays) while still exposing `nixpkgs-poetry` to the JupyterLab/Poetry environment configuration.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b1d1ae315efe8346f98af4d20a8d4d1fccbf7efa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->