### PR TITLE
fix: replace nodePackages.npm with top-level npm

### DIFF
--- a/lib/jupyter.nix
+++ b/lib/jupyter.nix
@@ -112,7 +112,7 @@
       # nodejs and npm are needed to be able to install extensions
       ++ (with pkgs; [
         nodejs
-        nodePackages.npm
+        npm
       ]);
 
     kernelDerivations = kernels;


### PR DESCRIPTION
nixpkgs-unstable removed `nodePackages` on 2026-03-03. Many packages that were under `nodePackages` are now available at the top level.

This replaces `nodePackages.npm` with `npm` in `lib/jupyter.nix` to fix evaluation errors against current nixpkgs-unstable.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a one-line dependency reference update to match nixpkgs changes; behavior should be identical aside from fixing eval on nixpkgs-unstable.
> 
> **Overview**
> Updates `lib/jupyter.nix` so `mkJupyterlab` includes top-level `npm` in `allRuntimePackages` instead of the removed `pkgs.nodePackages.npm`, fixing evaluation against current `nixpkgs-unstable`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d0ff5c70eea86a75429d68aabcc9879a14bcc70. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->